### PR TITLE
Document `comment` and `label` format functions

### DIFF
--- a/introduction/Formatting.rst
+++ b/introduction/Formatting.rst
@@ -41,6 +41,10 @@ Complex Type
 
 ``{bswap[;size]@value}`` will byte-swap ``value`` for a specified ``size`` (size of pointer per default).
 
+``{label@address}`` will print the (auto)label at ``address``.
+
+``{comment@address}`` will print the (auto)comment at ``address``.
+
 --------
 Examples
 --------


### PR DESCRIPTION
The functions were added in:
https://github.com/x64dbg/x64dbg/commit/cb045065d9ca7bfab87c5d1ea32c931486d9e8c1